### PR TITLE
Sprint5 b03528 reorder tabs by role

### DIFF
--- a/app/config/routes.js
+++ b/app/config/routes.js
@@ -1,9 +1,5 @@
 app.config(function ($routeProvider) {
     $routeProvider.
-    when('/management', {
-        redirectTo: '/management/services',
-        access: ["ROLE_ADMIN", "ROLE_WEB_MANAGER", "ROLE_SERVICE_MANAGER"]
-    }).
     when('/management/:tab', {
         templateUrl: 'views/management.html',
         access: ["ROLE_ADMIN", "ROLE_WEB_MANAGER", "ROLE_SERVICE_MANAGER"]

--- a/app/controllers/managementController.js
+++ b/app/controllers/managementController.js
@@ -1,81 +1,103 @@
 app.controller('ManagementController', function ($controller, $scope, UserService) {
+
     angular.extend(this, $controller('AbstractController', {
         $scope: $scope
     }));
 
-    var columns = {
-      "services": {
-        path: "services",
-        view: "services",
-        label: "Services"
-      },
-      "notes": {
-        path: "notes",
-        view: "notes",
-        label: "Notes"
-      },
-      "ideas": {
-        path: "ideas",
-        view: "ideas",
-        label: "Ideas"
-      },
-      "featureProposals": {
-        path: "feature-proposals",
-        view: "featureProposals",
-        label: "Feature Proposals"
-      },
-      "notifications": {
-        path: "notifications",
-        view: "notifications",
-        label: "Notifications"
-      },
-      "users": {
-        path: "users",
-        view: "users",
-        label: "Users"
-      }
-    };
-
-    $scope.user = UserService.getCurrentUser();
-
     $scope.columns = [];
 
-    if ($scope.user.role == "ROLE_ADMIN") {
-        $scope.columns = [
-            columns.services,
-            columns.notes,
-            columns.ideas,
-            columns.featureProposals,
-            columns.notifications,
-            columns.users
-        ];
-    }
-    else if ($scope.user.role == "ROLE_SERVICE_ADMIN") {
-        $scope.columns = [
-            columns.services,
-            columns.notes,
-            columns.ideas,
-            columns.featureProposals,
-            columns.notifications
-        ];
-    }
-    else if ($scope.user.role == "ROLE_SERVICE_MANAGER") {
-        $scope.columns = [
-            columns.services,
-            columns.notes,
-            columns.ideas,
-            columns.featureProposals,
-        ];
-    }
-    else if ($scope.user.role == "ROLE_WEB_MANAGER") {
-        $scope.columns = [
-            columns.notes,
-            columns.notifications
-        ];
-    }
-    else if ($scope.user.role == "ROLE_NOTICE_MANAGER") {
-        $scope.columns = [
-            columns.notifications
-        ];
-    }
+    $scope.getDefaultManagementTab = function () {
+        var columns = getColumns();
+        return "management/" + columns[0].path;
+    };
+
+    var columns = {
+        "services": {
+            path: "services",
+            view: "services",
+            label: "Services"
+        },
+        "notes": {
+            path: "notes",
+            view: "notes",
+            label: "Notes"
+        },
+        "ideas": {
+            path: "ideas",
+            view: "ideas",
+            label: "Ideas"
+        },
+        "featureProposals": {
+            path: "feature-proposals",
+            view: "featureProposals",
+            label: "Feature Proposals"
+        },
+        "notifications": {
+            path: "notifications",
+            view: "notifications",
+            label: "Notifications"
+        },
+        "users": {
+            path: "users",
+            view: "users",
+            label: "Users"
+        }
+    };
+
+    var getColumns = function () {
+        var columnDefinitions;
+        switch (sessionStorage.role) {
+            case "ROLE_ADMIN":
+                columnDefinitions = [
+                    columns.services,
+                    columns.notes,
+                    columns.ideas,
+                    columns.featureProposals,
+                    columns.notifications,
+                    columns.users
+                ];
+                break;
+            case "ROLE_SERVICE_ADMIN":
+                columnDefinitions = [
+                    columns.services,
+                    columns.notes,
+                    columns.ideas,
+                    columns.featureProposals,
+                    columns.notifications
+                ];
+                break;
+            case "ROLE_SERVICE_MANAGER":
+                columnDefinitions = [
+                    columns.services,
+                    columns.notes,
+                    columns.ideas,
+                    columns.featureProposals
+                ];
+                break;
+            case "ROLE_WEB_MANAGER":
+                columnDefinitions = [
+                    columns.notes,
+                    columns.notifications
+                ];
+                break;
+            case "ROLE_NOTICE_MANAGER":
+                columnDefinitions = [
+                    columns.notifications
+                ];
+                break;
+            default:
+                columnDefinitions = [];
+                break;
+        }
+        $scope.columns.length = 0;
+        for (var col of columnDefinitions) {
+            $scope.columns.push(col);
+        }
+        return $scope.columns;
+    };
+
+    UserService.userReady().then(function () {
+        getColumns();
+    });
+
 });

--- a/app/controllers/managementController.js
+++ b/app/controllers/managementController.js
@@ -1,7 +1,81 @@
-app.controller('ManagementController', function ($controller, $scope) {
-
+app.controller('ManagementController', function ($controller, $scope, UserService) {
     angular.extend(this, $controller('AbstractController', {
         $scope: $scope
     }));
 
+    var columns = {
+      "services": {
+        path: "services",
+        view: "services",
+        label: "Services"
+      },
+      "notes": {
+        path: "notes",
+        view: "notes",
+        label: "Notes"
+      },
+      "ideas": {
+        path: "ideas",
+        view: "ideas",
+        label: "Ideas"
+      },
+      "featureProposals": {
+        path: "feature-proposals",
+        view: "featureProposals",
+        label: "Feature Proposals"
+      },
+      "notifications": {
+        path: "notifications",
+        view: "notifications",
+        label: "Notifications"
+      },
+      "users": {
+        path: "users",
+        view: "users",
+        label: "Users"
+      }
+    };
+
+    $scope.user = UserService.getCurrentUser();
+
+    $scope.columns = [];
+
+    if ($scope.user.role == "ROLE_ADMIN") {
+        $scope.columns = [
+            columns.services,
+            columns.notes,
+            columns.ideas,
+            columns.featureProposals,
+            columns.notifications,
+            columns.users
+        ];
+    }
+    else if ($scope.user.role == "ROLE_SERVICE_ADMIN") {
+        $scope.columns = [
+            columns.services,
+            columns.notes,
+            columns.ideas,
+            columns.featureProposals,
+            columns.notifications
+        ];
+    }
+    else if ($scope.user.role == "ROLE_SERVICE_MANAGER") {
+        $scope.columns = [
+            columns.services,
+            columns.notes,
+            columns.ideas,
+            columns.featureProposals,
+        ];
+    }
+    else if ($scope.user.role == "ROLE_WEB_MANAGER") {
+        $scope.columns = [
+            columns.notes,
+            columns.notifications
+        ];
+    }
+    else if ($scope.user.role == "ROLE_NOTICE_MANAGER") {
+        $scope.columns = [
+            columns.notifications
+        ];
+    }
 });

--- a/app/controllers/managementController.js
+++ b/app/controllers/managementController.js
@@ -90,8 +90,8 @@ app.controller('ManagementController', function ($controller, $scope, UserServic
                 break;
         }
         $scope.columns.length = 0;
-        for (var col of columnDefinitions) {
-            $scope.columns.push(col);
+        for (var index = 0 ; index < columnDefinitions.length; index++) {
+            $scope.columns.push(columnDefinitions[index]);
         }
         return $scope.columns;
     };

--- a/app/index.html
+++ b/app/index.html
@@ -64,8 +64,8 @@
 
               <ul class="dropdown-menu" role="menu">
                 <li ng-if="isAdmin() || isAssuming() == 'true'" role="presentation" class="dropdown-header">Manager Actions</li>
-                <li ng-if="isAdmin() || isManager()">
-                  <a href="management">Management Dashboard</a>
+                <li ng-if="isAdmin() || isManager()" ng-controller="ManagementController">
+                  <a href="{{getDefaultManagementTab()}}">Management Dashboard</a>
                 </li>
                 <li ng-if="isAdmin() || isAssuming() == 'true'" role="presentation" class="divider"></li>
                 <li ng-if="isAdmin() || isAssuming() == 'true'" role="presentation" class="dropdown-header">Admin Actions</li>

--- a/app/views/management.html
+++ b/app/views/management.html
@@ -1,8 +1,10 @@
-<div class="row">
+<div class="row" ng-controller="ManagementController">
 
-  <div class="row" ng-controller="ManagementController">
+  <div class="row" ng-if="columns.length > 0">
 
     <wvr-tabs target="managementView">
+      <!-- TODO: fix wvr-tabs -->
+      <!-- <wvr-tab ng-repeat="col in columns" path="{{col.path}}" view="views/management/{{col.view}}.html" label="{{col.label}}">{{col.label}}</wvr-tab> -->
       <wvr-tab ng-show="columns[0]" path="{{columns[0].path}}" view="views/management/{{columns[0].view}}.html" label="{{columns[0].label}}">{{columns[0].label}}</wvr-tab>
       <wvr-tab ng-show="columns[1]" path="{{columns[1].path}}" view="views/management/{{columns[1].view}}.html" label="{{columns[1].label}}">{{columns[1].label}}</wvr-tab>
       <wvr-tab ng-show="columns[2]" path="{{columns[2].path}}" view="views/management/{{columns[2].view}}.html" label="{{columns[2].label}}">{{columns[2].label}}</wvr-tab>
@@ -11,7 +13,7 @@
       <wvr-tab ng-show="columns[5]" path="{{columns[5].path}}" view="views/management/{{columns[5].view}}.html" label="{{columns[5].label}}">{{columns[5].label}}</wvr-tab>
     </wvr-tabs>
 
-    <wvr-tabview class="management-vew" for="managementView"></wvr-tabview>
+    <wvr-tabview class="management-view" for="managementView"></wvr-tabview>
 
   </div>
 

--- a/app/views/management.html
+++ b/app/views/management.html
@@ -3,12 +3,12 @@
   <div class="row" ng-controller="ManagementController">
 
     <wvr-tabs target="managementView">
-      <wvr-tab path="services" view="views/management/services.html" label="Services">Services</wvr-tab>
-      <wvr-tab path="ideas" view="views/management/ideas.html" label="Notes">Ideas</wvr-tab>
-      <wvr-tab path="feature-proposals" view="views/management/featureProposals.html" label="Notes">Feature Proposals</wvr-tab>
-      <wvr-tab path="notes" view="views/management/notes.html" label="Notes">Notes</wvr-tab>
-      <wvr-tab path="notifications" view="views/management/notifications.html" label="notifications">Notifications</wvr-tab>
-      <wvr-tab path="users" view="views/management/users.html" label="users">Users</wvr-tab>
+      <wvr-tab ng-show="columns[0]" path="{{columns[0].path}}" view="views/management/{{columns[0].view}}.html" label="{{columns[0].label}}">{{columns[0].label}}</wvr-tab>
+      <wvr-tab ng-show="columns[1]" path="{{columns[1].path}}" view="views/management/{{columns[1].view}}.html" label="{{columns[1].label}}">{{columns[1].label}}</wvr-tab>
+      <wvr-tab ng-show="columns[2]" path="{{columns[2].path}}" view="views/management/{{columns[2].view}}.html" label="{{columns[2].label}}">{{columns[2].label}}</wvr-tab>
+      <wvr-tab ng-show="columns[3]" path="{{columns[3].path}}" view="views/management/{{columns[3].view}}.html" label="{{columns[3].label}}">{{columns[3].label}}</wvr-tab>
+      <wvr-tab ng-show="columns[4]" path="{{columns[4].path}}" view="views/management/{{columns[4].view}}.html" label="{{columns[4].label}}">{{columns[4].label}}</wvr-tab>
+      <wvr-tab ng-show="columns[5]" path="{{columns[5].path}}" view="views/management/{{columns[5].view}}.html" label="{{columns[5].label}}">{{columns[5].label}}</wvr-tab>
     </wvr-tabs>
 
     <wvr-tabview class="management-vew" for="managementView"></wvr-tabview>


### PR DESCRIPTION
This re-orders tabs based on current role.

The use of `ng-repeat` is preferred but the current design of `wvr-tabs` prevents this from working as expected. `ng-show` is used instead.

The routing had to be changed for the default tab to be properly selected.