### PR TITLE
Fix regression in D-01186, introduced by B-03523

### DIFF
--- a/app/filters/dashboardServicesFilter.js
+++ b/app/filters/dashboardServicesFilter.js
@@ -4,7 +4,7 @@ app.filter('dashboardServices', function () {
         var resultingArr = [];
         if (condition1) {
             angular.forEach(arr, function (el) {
-                if (el[condition2] || el.status === 'DOWN') {
+                if (el[condition2]) {
                     resultingArr.push(el);
                 }
             });
@@ -19,7 +19,7 @@ app.filter('dashboardServices', function () {
       var remaining = [];
 
       angular.forEach(arr, function (el) {
-          if (el.status === filterStatus) {
+          if (filterStatus.indexOf(el.status) >= 0) {
             filtered.push(el);
           }
           else {
@@ -35,7 +35,7 @@ app.filter('dashboardServices', function () {
 
     return function (services, options) {
         var shownServices = reduceArray(services, options.showPublic(), "isPublic");
-        var byStatus = filterByStatus(shownServices, "MAINTENANCE");
+        var byStatus = filterByStatus(shownServices, ["MAINTENANCE", "DOWN"]);
         var shortList = reduceArray(byStatus.remaining, options.showShortList, "onShortList");
         return byStatus.filtered.concat(shortList);
     };


### PR DESCRIPTION
The solution for B-03523 incorrectly tests when the status is set to "DOWN".
It appears to be testings if the service is visible to the public OR if the status is "DOWN".
This ends up exposing non-public services to anonymous, thereby re-introducing D-01186.

Change the filterByStatus() condition parameter to an array so that multiple status can be checked via a single pass.