### PR TITLE
Reloading ServiceRepo on route change to clear out management view pages

### DIFF
--- a/app/controllers/dashboardController.js
+++ b/app/controllers/dashboardController.js
@@ -4,6 +4,10 @@ app.controller("DashboardController", function ($controller, $scope, UserService
         $scope: $scope
     }));
 
+    $scope.$on('$routeChangeSuccess', function () {
+        ServiceRepo.reset();
+    });
+
     $scope.overallStatus = $scope.isFullServiceConsumer() ? new OverallStatusFull() : new OverallStatusPublic();
 
     $scope.services = ServiceRepo.getAll();

--- a/app/controllers/dashboardController.js
+++ b/app/controllers/dashboardController.js
@@ -4,9 +4,8 @@ app.controller("DashboardController", function ($controller, $scope, UserService
         $scope: $scope
     }));
 
-    $scope.$on('$routeChangeSuccess', function () {
-        ServiceRepo.reset();
-    });
+    // Clear out any cached pages and get full list of services.
+    ServiceRepo.reset();
 
     $scope.overallStatus = $scope.isFullServiceConsumer() ? new OverallStatusFull() : new OverallStatusPublic();
 

--- a/tests/mocks/repo/mockServiceRepo.js
+++ b/tests/mocks/repo/mockServiceRepo.js
@@ -125,4 +125,6 @@ angular.module('mock.serviceRepo', []).service('ServiceRepo', function ($q) {
         return defer.promise;
     };
 
+    ServiceRepo.reset = function () {};
+
 });


### PR DESCRIPTION
When you navigate from the management view to the dashboard, the page of services is all that is displayed. This corrects the issue by resetting the repo.