### PR TITLE
Issue 173: Provide confirmation after submitting idea or issue

### DIFF
--- a/app/views/request/request.html
+++ b/app/views/request/request.html
@@ -13,6 +13,7 @@
       </div>
     </div>
     <div class="col-sm-8 col-sm-offset-2" ng-show="type">
+      <alerts seconds="45" channels="services/feature,services/issue" types="SUCCESS"></alerts>
       <center>
         <h3>Please provide a title and a description for
           <span>{{type === 'FEATURE' ? 'feature or idea' : 'issue or bug'}}</span>.</h3>

--- a/tests/mocks/repo/mockUserRepo.js
+++ b/tests/mocks/repo/mockUserRepo.js
@@ -68,5 +68,24 @@ var mockUserRepo3 = {
 };
 
 angular.module('mock.userRepo', []).service('UserRepo', function ($q) {
-    return this;
+    var userRepo = this;
+    var defer;
+    var payloadResponse = function (payload) {
+        return defer.resolve({
+            body: angular.toJson({
+                meta: {
+                    status: 'SUCCESS'
+                },
+                payload: payload
+            })
+        });
+    };
+
+    userRepo.getUser = function () {
+        defer = $q.defer();
+        payloadResponse({ User: {id : 1} });
+        return defer.promise;
+    };
+
+    return userRepo;
 });


### PR DESCRIPTION
The messages are already handled, however, when going directly to a URL (such as with "/ISSUE" or the "/FEATURE" URL path suffixes) the messages never get displayed.
This adds the appropriate SUCCESS message handling block.

Relates TAMULib/LibraryServiceStatusSystemService#91
Resolves #173 