### PR TITLE
Issue 168: Modal does not close when a Feature Request is submitted.

### DIFF
--- a/app/services/productService.js
+++ b/app/services/productService.js
@@ -33,16 +33,7 @@ app.service('ProductService', function ($q, WsApi) {
         angular.extend(apiMapping.Product.submitFeatureProposal, {
             'data': fp
         });
-        return $q(function (resolve, reject) {
-            WsApi.fetch(apiMapping.Product.submitFeatureProposal).then(function (response) {
-                var apiRes = angular.fromJson(response.body);
-                if (apiRes.meta.status === 'SUCCESS') {
-                    resolve();
-                } else {
-                    reject();
-                }
-            });
-        });
+        return WsApi.fetch(apiMapping.Product.submitFeatureProposal);
     };
 
 });

--- a/tests/mocks/services/mockProductService.js
+++ b/tests/mocks/services/mockProductService.js
@@ -83,7 +83,7 @@ angular.module('mock.productService', []).service('ProductService', function ($q
 
     this.submitFeatureProposal = function (fp) {
         defer = $q.defer();
-        payloadResponse();
+        payloadResponse(fp);
         return defer.promise;
     };
 


### PR DESCRIPTION
The payload response is being handled twice.
The first time it gets handled nothing is passed, so the second handler only gets NULL.
Just directly return the response so that the second handler becomes the only handler.

resolves #168 