### PR TITLE
Disable relative url conversion in tinymce

### DIFF
--- a/app/controllers/notificationController.js
+++ b/app/controllers/notificationController.js
@@ -118,7 +118,10 @@ app.controller('NotificationController', function ($controller, $scope, Notifica
         selector: 'textarea',
         theme: "modern",
         plugins: "link lists textcolor",
-        toolbar: "undo redo | formatselect bold italic separator | alignleft aligncenter alignright | numlist bullist | forecolor backcolor"
+        toolbar: "undo redo | formatselect bold italic separator | alignleft aligncenter alignright | numlist bullist | forecolor backcolor",
+        relative_urls: false,
+        remove_script_host : false,
+        convert_urls : true
     };
 
 });


### PR DESCRIPTION
Resolves #216 

The links added through TinyMCE need to be full urls in order to provide working links in all contexts.