### PR TITLE
Issue 234: Security fixes for: minimatch and qs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   "devDependencies": {
   },
   "overrides": {
-    "glob-stream": "^7.0.0"
+    "glob-stream": "^7.0.0",
+    "minimatch": "^3.1.2",
+    "qs": "^6.11.0"
   }
 }


### PR DESCRIPTION
# Description

Fix child dependencies that are coming in with insecure versions. This is based on the `npm list --depth=100` and considers what is reported by dependabot for Sage.

see: https://github.com/TAMULib/SAGE/security/dependabot/37
see: https://github.com/TAMULib/SAGE/security/dependabot/34

Fixes #234

## Type of change

Please delete options that are not relevant.

- [x] Security related.

# How Has This Been Tested?

- [X] Not tested, Needs QA.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

