### PR TITLE
Tinymce fix notifications

### DIFF
--- a/.wvr/build-config.js
+++ b/.wvr/build-config.js
@@ -70,24 +70,6 @@ const config = {
       from: './node_modules/bootstrap/dist/css/bootstrap.min.css.map',
       to: './resources/styles/bootstrap/dist/css/bootstrap.min.css.map',
     },
-    {
-      from: './node_modules/tinymce/plugins/**/plugin.js',
-      to({ context, absoluteFilename }) {
-        return `${absoluteFilename.replace(/^.*\/node_modules\/tinymce\/plugins\//, "plugins/")}`;
-      },
-    },
-    {
-      from: './node_modules/tinymce/themes/**/theme.js',
-      to({ context, absoluteFilename }) {
-        return `${absoluteFilename.replace(/^.*\/node_modules\/tinymce\/themes\//, "themes/")}`;
-      },
-    },
-    {
-      from: './node_modules/tinymce/skins/**/*.css',
-      to({ context, absoluteFilename }) {
-        return `${absoluteFilename.replace(/^.*\/node_modules\/tinymce\/skins\//, "skins/")}`;
-      },
-    },
   ],
   entry: {
     app: [

--- a/app/controllers/notificationController.js
+++ b/app/controllers/notificationController.js
@@ -111,17 +111,19 @@ app.controller('NotificationController', function ($controller, $scope, Notifica
 
     NotificationRepo.ready().then(function () {
         buildTable();
+
+        document.addEventListener("contentSave", function (e) {
+            $scope.notificationData.body = e.detail.data;
+            $scope.save();
+        });
+
+        $scope.save = function () {
+            $scope.notificationData.body = encodeURIComponent($scope.notificationData.body);
+            $scope.notificationData.update($scope.notificationData);
+            $scope.notificationData.body = decodeURIComponent($scope.notificationData.body);
+        };
+
         $scope.tableParams.reload();
     });
-
-    $scope.tinymceOptions = {
-        selector: 'textarea',
-        theme: "modern",
-        plugins: "link lists",
-        toolbar: "undo redo | formatselect bold italic separator | alignleft aligncenter alignright | numlist bullist | forecolor backcolor",
-        relative_urls: false,
-        remove_script_host : false,
-        convert_urls : true
-    };
 
 });

--- a/app/controllers/notificationController.js
+++ b/app/controllers/notificationController.js
@@ -27,14 +27,16 @@ app.controller('NotificationController', function ($controller, $scope, $timeout
 
     $scope.forms = {};
 
-    $scope.notificationToDelete = {};
-
-    $scope.notificationData = new Notification({
+    var emptyNotification = {
         name: '',
         body: '',
         active: false,
         locations: []
-    });
+    };
+
+    $scope.notificationToDelete = new Notification(emptyNotification);
+
+    $scope.notificationData = new Notification(emptyNotification);
 
     $scope.resetNotifications = function () {
         $scope.notificationData.refresh();
@@ -45,13 +47,7 @@ app.controller('NotificationController', function ($controller, $scope, $timeout
                 $scope.forms[key].$setPristine();
             }
         }
-        Object.assign($scope.notificationData, {
-            id: undefined,
-            name: '',
-            body: '',
-            active: false,
-            locations: []
-        });
+        Object.assign($scope.notificationData, emptyNotification);
         $scope.closeModal();
     };
 
@@ -101,7 +97,7 @@ app.controller('NotificationController', function ($controller, $scope, $timeout
             if (angular.fromJson(res.body).meta.status === 'SUCCESS') {
                 $scope.closeModal();
                 $scope.deleting = false;
-                $scope.notificationToDelete = {};
+                Object.assign($scope.notificationToDelete, emptyNotification);
                 $scope.tableParams.reload();
             }
         });

--- a/app/controllers/notificationController.js
+++ b/app/controllers/notificationController.js
@@ -65,9 +65,9 @@ app.controller('NotificationController', function ($controller, $scope, $timeout
         Object.assign($scope.notificationData, notification);
         $timeout(function () {
             $scope.openModal('#editNotificationModal');
-            const modal = angular.element('#editNotificationModal');
+            var modal = angular.element('#editNotificationModal');
             if (modal) {
-                const iframe = modal.find("iframe");
+                var iframe = modal.find("iframe");
                 if (iframe && iframe.length >= 1) {
                     iframe[0].contentDocument.body.innerHTML = notification.body;
                 }

--- a/app/controllers/notificationController.js
+++ b/app/controllers/notificationController.js
@@ -1,4 +1,4 @@
-app.controller('NotificationController', function ($controller, $scope, Notification, NotificationRepo, NgTableParams) {
+app.controller('NotificationController', function ($controller, $scope, $timeout, Notification, NotificationRepo, NgTableParams) {
 
     angular.extend(this, $controller('AbstractScheduleController', {
         $scope: $scope
@@ -29,17 +29,24 @@ app.controller('NotificationController', function ($controller, $scope, Notifica
 
     $scope.notificationToDelete = {};
 
+    $scope.notificationData = new Notification({
+        name: '',
+        body: '',
+        active: false,
+        locations: []
+    });
+
     $scope.resetNotifications = function () {
-        if ($scope.notificationData) {
-            $scope.notificationData.refresh();
-            $scope.notificationData.clearValidationResults();
-        }
+        $scope.notificationData.refresh();
+        $scope.notificationData.clearValidationResults();
+
         for (var key in $scope.forms) {
             if (!$scope.forms[key].$pristine) {
                 $scope.forms[key].$setPristine();
             }
         }
-        $scope.notificationData = new Notification({
+        Object.assign($scope.notificationData, {
+            id: undefined,
             name: '',
             body: '',
             active: false,
@@ -59,15 +66,17 @@ app.controller('NotificationController', function ($controller, $scope, Notifica
     };
 
     $scope.editNotification = function (notification) {
-        $scope.notificationData = notification;
-        $scope.openModal('#editNotificationModal');
-        const modal = angular.element('#editNotificationModal');
-        if (modal) {
-            const iframe = modal.find("iframe");
-            if (iframe && iframe.length >= 1) {
-                iframe[0].contentDocument.body.innerHTML = notification.body;
+        Object.assign($scope.notificationData, notification);
+        $timeout(function () {
+            $scope.openModal('#editNotificationModal');
+            const modal = angular.element('#editNotificationModal');
+            if (modal) {
+                const iframe = modal.find("iframe");
+                if (iframe && iframe.length >= 1) {
+                    iframe[0].contentDocument.body.innerHTML = notification.body;
+                }
             }
-        }
+        });
     };
 
     $scope.updateNotification = function () {
@@ -80,8 +89,10 @@ app.controller('NotificationController', function ($controller, $scope, Notifica
     };
 
     $scope.confirmDelete = function (notification) {
-        $scope.openModal('#deleteNotificationModal');
-        $scope.notificationToDelete = notification;
+        Object.assign($scope.notificationToDelete, notification);
+        $timeout(function() {
+            $scope.openModal('#deleteNotificationModal');
+        });
     };
 
     $scope.deleteNotification = function () {

--- a/app/controllers/notificationController.js
+++ b/app/controllers/notificationController.js
@@ -61,8 +61,13 @@ app.controller('NotificationController', function ($controller, $scope, Notifica
     $scope.editNotification = function (notification) {
         $scope.notificationData = notification;
         $scope.openModal('#editNotificationModal');
-        const iframe = angular.element('#editNotificationModal').find("iframe")[0];
-        iframe.contentDocument.body.innerHTML = notification.body;
+        const modal = angular.element('#editNotificationModal');
+        if (modal) {
+            const iframe = modal.find("iframe");
+            if (iframe && iframe.length >= 1) {
+                iframe[0].contentDocument.body.innerHTML = notification.body;
+            }
+        }
     };
 
     $scope.updateNotification = function () {

--- a/app/controllers/notificationController.js
+++ b/app/controllers/notificationController.js
@@ -61,6 +61,8 @@ app.controller('NotificationController', function ($controller, $scope, Notifica
     $scope.editNotification = function (notification) {
         $scope.notificationData = notification;
         $scope.openModal('#editNotificationModal');
+        const iframe = angular.element('#editNotificationModal').find("iframe")[0];
+        iframe.contentDocument.body.innerHTML = notification.body;
     };
 
     $scope.updateNotification = function () {

--- a/app/views/modals/addNotificationModal.html
+++ b/app/views/modals/addNotificationModal.html
@@ -14,7 +14,7 @@
 
     <label>Notification Body</label>
     <div class="alert alert-wrapper alert-danger" ng-if="notificationRepo.getValidationResults().messages.body.minlength">{{ notificationRepo.getValidationResults().messages.body.minlength }}</div>
-    <textarea ui-tinymce="tinymceOptions" ng-model="notificationData.body"></textarea>
+    <tl-wysiwyg initial-value="{{notificationData.body}}" emit-event="contentSave"></tl-wysiwyg>
     <br />
 
     <label for="locationSelect">Locations</label>

--- a/app/views/modals/editNotificationModal.html
+++ b/app/views/modals/editNotificationModal.html
@@ -13,7 +13,8 @@
     <validatedinput model="notificationData" property="name" label="Name" placeholder="Name of the Notification" form="forms.update" validations="notificationRepo.getValidations()" results="notificationRepo.getValidationResults()"></validatedinput>
 
     <label>Notification Body</label>
-    <textarea ui-tinymce="tinymceOptions" ng-model="notificationData.body"></textarea>
+    <tl-wysiwyg class="edit-notification-wysiwyg" initial-value="{{notificationData.body}}" emit-event="contentSave"></tl-wysiwyg>
+
     <br />
 
     <label for="locationSelect">Locations</label>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "angular-ui-tinymce": "0.0.19",
     "ng-csv": "0.3.6",
     "ng-table": "3.0.1",
-    "tinymce": "7.0.0"
+    "tinymce": "^4.9"
   },
   "devDependencies": {
   },

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "@wvr/core": "2.2.6",
     "angular-ui-tinymce": "0.0.19",
     "ng-csv": "0.3.6",
-    "ng-table": "3.0.1",
-    "tinymce": "^4.9"
+    "ng-table": "3.0.1"
   },
   "devDependencies": {
   },

--- a/tests/unit/controllers/notificationControllerTest.js
+++ b/tests/unit/controllers/notificationControllerTest.js
@@ -9,10 +9,11 @@ describe('controller: NotificationController', function () {
         module('mock.notification');
         module('mock.notificationRepo');
 
-        inject(function ($controller, $q, $rootScope, _NgTableParams_, _Notification_, _NotificationRepo_) {
+        inject(function ($controller, $q, $rootScope, $timeout, _NgTableParams_, _Notification_, _NotificationRepo_) {
             installPromiseMatchers();
             q = $q;
             scope = $rootScope.$new();
+            timeout = $timeout;
 
             controller = $controller('NotificationController', {
                 $scope: scope,
@@ -72,13 +73,14 @@ describe('controller: NotificationController', function () {
 
     describe('Are the scope methods working as expected', function () {
         it('resetNotifications should reset notifications', function () {
-            var notification;
-            scope.notificationData = null;
+            var notification = new Notification();
+            scope.notificationData = notification;
             scope.closeModal = function() {};
 
             spyOn(scope, 'closeModal');
 
             scope.resetNotifications();
+            scope.$digest();
 
             expect(scope.closeModal).toHaveBeenCalled();
             expect(scope.ideaData).not.toEqual(null);
@@ -109,14 +111,14 @@ describe('controller: NotificationController', function () {
             expect(notification.clearValidationResults).toHaveBeenCalled();
         });
         it('editNotification should open a modal', function () {
-            scope.notificationData = null;
             scope.openModal = function(name) { };
 
             spyOn(scope, 'openModal');
 
             scope.editNotification(mockNotification1);
+            timeout.flush();
+            scope.$digest();
 
-            expect(scope.notificationData).toEqual(mockNotification1);
             expect(scope.openModal).toHaveBeenCalled();
         });
 
@@ -133,14 +135,14 @@ describe('controller: NotificationController', function () {
             expect(scope.notificationRepo.update).toHaveBeenCalled();
         });
         it('confirmDelete should should open a modal', function () {
-            scope.notificationToDelete = null;
             scope.openModal = function(name) { };
 
             spyOn(scope, 'openModal');
 
             scope.confirmDelete(mockNotification1);
+            timeout.flush();
+            scope.$digest();
 
-            expect(scope.notificationToDelete).toEqual(mockNotification1);
             expect(scope.openModal).toHaveBeenCalled();
         });
         it('deleteNotification should delete a notification', function () {


### PR DESCRIPTION
# Description

Two things; one the tinymce wysiwyg was not receiving the notification data on update. This is inconsistent with expected use and unknown cause with the tamu-library-component. Adding timeout to digest cycle and reserving the binding with notification data from the scope to the modal resolved this issue.

Until tl-wysiwyg affords consistent binding here is the workaround:

```
            const modal = angular.element('#editNotificationModal');
            if (modal) {
                const iframe = modal.find("iframe");
                if (iframe && iframe.length >= 1) {
                    iframe[0].contentDocument.body.innerHTML = notification.body;
                }
            }
```            


Fixes #245 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test locally with various notifications created and modified.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

